### PR TITLE
Various fixes

### DIFF
--- a/examples/outputs.tf
+++ b/examples/outputs.tf
@@ -1,8 +1,3 @@
-output "policy_arn" {
-  description = "ARN for the new policy"
-  value       = "${module.example_team_ecr_credentials.policy_arn}"
-}
-
 output "access_key_id" {
   description = "Access key id for the credentials"
   value       = "${module.example_team_ecr_credentials.access_key_id}"

--- a/examples/outputs.tf
+++ b/examples/outputs.tf
@@ -12,3 +12,8 @@ output "repo_arn" {
   description = "ECR repo ARN"
   value       = "${module.example_team_ecr_credentials.repo_arn}"
 }
+
+output "repo_url" {
+  description = "ECR repo URL"
+  value       = "${module.example_team_ecr_credentials.repo_url}"
+}

--- a/examples/outputs.tf
+++ b/examples/outputs.tf
@@ -8,11 +8,6 @@ output "secret_access_key" {
   value       = "${module.example_team_ecr_credentials.secret_access_key}"
 }
 
-output "user_name" {
-  description = "User name for the new credentials"
-  value       = "${module.example_team_ecr_credentials.user_name}"
-}
-
 output "repo_arn" {
   description = "ECR repo ARN"
   value       = "${module.example_team_ecr_credentials.repo_arn}"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,10 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+resource "aws_ecr_repository" "repo" {
+  name = "${var.team_name}/${var.repo_name}"
+}
+
 resource "random_id" "user" {
   byte_length = 8
 }
@@ -31,7 +35,7 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.team_name}/*",
+      "${aws_ecr_repository.repo.arn}",
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,13 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+resource "random_id" "user" {
+  byte_length = 8
+}
+
 resource "aws_iam_user" "user" {
-  name = "${var.team_name}-ecr-system-account"
-  path = "/teams/${var.team_name}/"
+  name = "ecr-user-${random_id.user.hex}"
+  path = "/system/ecr-user/${var.team_name}/"
 }
 
 resource "aws_iam_access_key" "key" {

--- a/main.tf
+++ b/main.tf
@@ -42,14 +42,8 @@ data "aws_iam_policy_document" "policy" {
   }
 }
 
-resource "aws_iam_policy" "policy" {
-  name        = "${var.team_name}-ecr-read-write"
-  path        = "/teams/${var.team_name}/"
-  policy      = "${data.aws_iam_policy_document.policy.json}"
-  description = "ECR policy for team ${var.team_name}"
-}
-
-resource "aws_iam_user_policy_attachment" "policy-attachment" {
-  user       = "${aws_iam_user.user.name}"
-  policy_arn = "${aws_iam_policy.policy.arn}"
+resource "aws_iam_user_policy" "policy" {
+  name   = "ecr-read-write"
+  policy = "${data.aws_iam_policy_document.policy.json}"
+  user   = "${aws_iam_user.user.name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-output "policy_arn" {
-  description = "ARN for the new policy"
-  value       = "${aws_iam_policy.policy.arn}"
-}
-
 output "access_key_id" {
   description = "Access key id for the credentials"
   value       = "${aws_iam_access_key.key.id}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "secret_access_key" {
   value       = "${aws_iam_access_key.key.secret}"
 }
 
-output "user_name" {
-  description = "User name for the new credentials"
-  value       = "${aws_iam_user.user.name}"
-}
-
 output "repo_arn" {
   description = "ECR repository ARN"
   value       = "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.team_name}/${var.repo_name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,10 @@ output "secret_access_key" {
 
 output "repo_arn" {
   description = "ECR repository ARN"
-  value       = "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.team_name}/${var.repo_name}"
+  value       = "${aws_ecr_repository.repo.arn}"
+}
+
+output "repo_url" {
+  description = "ECR repository URL"
+  value       = "${aws_ecr_repository.repo.repository_url}"
 }


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/162

- Previously, the repo was not actually created.
- The IAM user that's created now uses a random identifier to prevent clashes.
- The IAM policy for the user is now embedded on the user; it's not re-usable so we don't need to have a policy resource created.

With this iteration, repository name clashes are possible within a team. The product team should make sure that doesn't happen but if it does, terraform will refuse to apply since a repository already exists.