### PR TITLE
Add/lifecycle policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ module "best_team_ecr_credentials" {
 |------|-------------|:----:|:-----:|:-----:|
 | repo_name | name of the repository to be created | string | - | yes |
 | team_name | name of the team creating the credentials | string | - | yes |
+| enable_policy | Sets a ECR lifecycle policy to delete every image after count 900 | string | true | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ module "best_team_ecr_credentials" {
 |------|-------------|:----:|:-----:|:-----:|
 | repo_name | name of the repository to be created | string | - | yes |
 | team_name | name of the team creating the credentials | string | - | yes |
-| enable_policy | Sets a ECR lifecycle policy to delete every image after count 900 | string | true | yes |
+| enable_policy | Sets a ECR lifecycle policy to delete every image after count 40 | string | true | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -14,11 +14,11 @@ resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
     "rules": [
         {
             "rulePriority": 2,
-            "description": "Expire images over count 900",
+            "description": "Expire images over count 40",
             "selection": {
                 "tagStatus": "any",
                 "countType": "imageCountMoreThan",
-                "countNumber": 900
+                "countNumber": 40
             },
             "action": {
                 "type": "expire"

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,30 @@ resource "aws_ecr_repository" "repo" {
   name = "${var.team_name}/${var.repo_name}"
 }
 
+resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
+  repository = "${aws_ecr_repository.repo.name}"
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire images older than 14 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 14
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}
+
 resource "random_id" "user" {
   byte_length = 8
 }

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ resource "aws_ecr_repository" "repo" {
 }
 
 resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
+  count = "${var.enable_policy ? 1 : 0}"
   repository = "${aws_ecr_repository.repo.name}"
 
   policy = <<EOF

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "aws_ecr_repository" "repo" {
 }
 
 resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
-  count = "${var.enable_policy ? 1 : 0}"
+  count      = "${var.enable_policy ? 1 : 0}"
   repository = "${aws_ecr_repository.repo.name}"
 
   policy = <<EOF

--- a/main.tf
+++ b/main.tf
@@ -12,13 +12,12 @@ resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
 {
     "rules": [
         {
-            "rulePriority": 1,
-            "description": "Expire images older than 14 days",
+            "rulePriority": 2,
+            "description": "Expire images over count 900",
             "selection": {
-                "tagStatus": "untagged",
-                "countType": "sinceImagePushed",
-                "countUnit": "days",
-                "countNumber": 14
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 900
             },
             "action": {
                 "type": "expire"

--- a/variables.tf
+++ b/variables.tf
@@ -4,5 +4,5 @@ variable "team_name" {}
 
 variable "enable_policy" {
   description = "Sets a ECR lifecycle policy to delete every image after count 900. Default is true."
-  default = true
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
 variable "repo_name" {}
 
 variable "team_name" {}
+
+variable "enable_policy" {
+  description = "Sets a ECR lifecycle policy to delete every image after count 900. Default is true."
+  default = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,6 @@ variable "repo_name" {}
 variable "team_name" {}
 
 variable "enable_policy" {
-  description = "Sets a ECR lifecycle policy to delete every image after count 900. Default is true."
+  description = "Sets a ECR lifecycle policy to delete every image after count 40. Default is true."
   default     = true
 }


### PR DESCRIPTION
Connects to ministryofjustice/cloud-platform#602

Adds an optional ECR lifecycle policy to the ECR repo that's configured when running the terraform.