### PR TITLE
Split the provided example into separate files

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,10 @@ The output will be in a kubernetes `Secret`, which includes the values of `acces
 
 In your namespace's path in the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/) repository, create a directory called `resources` (if you have not created one already) and refer to the contents of [main.tf](main.tf) to define the module properties. Make sure to change placeholder values to what is appropriate and refer to the top-level README file in this repository for extra variables that you can use to further customise your resource.
 
+If you do not have a `main.tf` file already, you can use the one provided here, with any necessary changes. If you already have a `main.tf` file in your `resources` directory, you can ignore this one.
+
+Copy the `ecr.tf` file to your `resources` directory, and make any required changes.
+
 Commit your changes to a branch and raise a pull request. Once approved, you can merge and the changes will be applied. Shortly after, you should be able to access the `Secret` on kubernetes and acccess the resources. The generated key allows access to all the Docker repositories tagged with the team's name. You might want to refer to the [documentation on Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 ## From your laptop

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -1,0 +1,26 @@
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "example_team_ecr_credentials" {
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
+  repo_name  = "example-module"
+  team_name  = "example-team"
+  aws_region = "eu-west-2"                                                                     # this overwrite the region from the provider defined above.
+}
+
+resource "kubernetes_secret" "example_team_ecr_credentials" {
+  metadata {
+    name      = "example-team-ecr-credentials-output"
+    namespace = "my-namespace"
+  }
+
+  data {
+    access_key_id     = "${module.example_team_ecr_credentials.access_key_id}"
+    secret_access_key = "${module.example_team_ecr_credentials.secret_access_key}"
+    repo_arn          = "${module.example_team_ecr_credentials.repo_arn}"
+    repo_url          = "${module.example_team_ecr_credentials.repo_url}"
+  }
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -5,30 +5,3 @@ terraform {
 provider "aws" {
   region = "eu-west-1"
 }
-
-/*
- * Make sure that you use the latest version of the module by changing the
- * `ref=` value in the `source` attribute to the latest version listed on the
- * releases page of this repository.
- *
- */
-module "example_team_ecr_credentials" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.1"
-  repo_name  = "example-module"
-  team_name  = "example-team"
-  aws_region = "eu-west-2"                                                                     # this overwrite the region from the provider defined above. 
-}
-
-resource "kubernetes_secret" "example_team_ecr_credentials" {
-  metadata {
-    name      = "example-team-ecr-credentials-output"
-    namespace = "my-namespace"
-  }
-
-  data {
-    access_key_id     = "${module.example_team_ecr_credentials.access_key_id}"
-    secret_access_key = "${module.example_team_ecr_credentials.secret_access_key}"
-    repo_arn          = "${module.example_team_ecr_credentials.repo_arn}"
-    repo_url          = "${module.example_team_ecr_credentials.repo_url}"
-  }
-}


### PR DESCRIPTION
Rather than having a single `main.tf` file, provide a minimal
`main.tf` here, and a separate `ecr.tf` file which contains the
actual code that the user cares about.

This makes it more explicit that the user should create an `ecr.tf` file
in their `resources` folder, and avoids terraform errors if they define
provider and backend multiple times (by copying multiple files which
define those - e.g. an `ecr.tf` and an `rds.tf`).