### PR TITLE
Replace markdown version badge with html tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AWS ECR Terraform module
 
-[![Releases](https://img.shields.io/github/release/ministryofjustice/cloud-platform-terraform-ecr-credentials/all.svg?style=flat-square)](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/releases)
+<a href="https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/releases">
+  <img src="https://img.shields.io/github/release/ministryofjustice/cloud-platform-terraform-ecr-credentials/all.svg" alt="Releases" />
+</a>
 
 This terraform module will create an ECR repository and IAM credentials to access it.
 


### PR DESCRIPTION
Github seems to intermittently fail to render the markdown correctly. HTML seems to work more reliably.