### PR TITLE
Remove ECR lifecycle policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 terraform: &terraform
   docker:
-    - image: hashicorp/terraform:light
+    - image: hashicorp/terraform:0.11.11
   working_directory: /tmp/workspace/terraform
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Note: From version 3.0 of this module, The AWS region  will default to eu-west-2
 |------|-------------|:----:|:-----:|:-----:|
 | repo_name | name of the repository to be created | string | - | yes |
 | team_name | name of the team creating the credentials | string | - | yes |
-| enable_policy | Sets a ECR lifecycle policy to delete every image after count 100 | string | true | yes
 | aws_region | region into which the resource will be created | string | eu-west-2 | no
 | providers | provider creating resources | arrays of string | default provider | no
 

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.3"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=3.4"
   repo_name = "example-module"
   team_name = "example-team"
 

--- a/main.tf
+++ b/main.tf
@@ -5,30 +5,6 @@ resource "aws_ecr_repository" "repo" {
   name = "${var.team_name}/${var.repo_name}"
 }
 
-resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
-  count      = "${var.enable_policy ? 1 : 0}"
-  repository = "${aws_ecr_repository.repo.name}"
-
-  policy = <<EOF
-{
-    "rules": [
-        {
-            "rulePriority": 2,
-            "description": "Expire images over count 100",
-            "selection": {
-                "tagStatus": "any",
-                "countType": "imageCountMoreThan",
-                "countNumber": 100
-            },
-            "action": {
-                "type": "expire"
-            }
-        }
-    ]
-}
-EOF
-}
-
 resource "random_id" "user" {
   byte_length = 8
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,11 +2,6 @@ variable "repo_name" {}
 
 variable "team_name" {}
 
-variable "enable_policy" {
-  description = "Sets a ECR lifecycle policy to delete every image after count 100. Default is true."
-  default     = true
-}
-
 variable "aws_region" {
   description = "Region into which the resource will be created."
   default     = "eu-west-2"


### PR DESCRIPTION
This is related to #905

As we want to remove the ECR lifecycle policy instead have a monitoring/alerting of Docker image counts.