### PR TITLE
remove "deprecated input" comment

### DIFF
--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -9,8 +9,6 @@ module "example_team_ecr_credentials" {
   repo_name = "example-module"
   team_name = "example-team"
 
-  # aws_region = "eu-west-2"     # This input is deprecated from version 3.2 of this module
-
   providers = {
     aws = aws.london
   }


### PR DESCRIPTION
Only the latest version of this module is being used, so we don't need to talk about earlier versions.