### PR TITLE
bumped version of example/ecr.tf to 4.1 for ecr scanning

### DIFF
--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.0"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
   repo_name = "example-module"
   team_name = "example-team"
   /*


### PR DESCRIPTION
bumped version in example/ecr.tf to latest 4.1 (scan upon push enabled by default)