### PR TITLE
Bugfix: Set a valid name for the ECR repo

### DIFF
--- a/template/ecr.tmpl
+++ b/template/ecr.tmpl
@@ -2,7 +2,7 @@ module "ecr-repo" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
 
   team_name = var.team_name
-  repo_name = var.repo_name
+  repo_name = "${var.namespace}-ecr"
 }
 
 resource "kubernetes_secret" "ecr-repo" {


### PR DESCRIPTION
There is no "repo_name" variable in the default resources/variables.tf
file that the CLI creates, so this template was invalid.
The change means the ECR repo will be named according to the namespace
name (e.g. `ecr-repo-david-test`).
