### PR TITLE
Create github actions secrets for CI/CD pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,6 @@
 
 This terraform module will create an ECR repository and IAM credentials to access it.
 
-## Usage
-
-**This module will create the resources in the region of the providers specified in the `providers` input.**
-
-**Be sure to create the relevant providers, see example/main.tf**
-
-**From module version 3.2, this replaces the use of the `aws_region`.**
-
-```hcl
-module "best_team_ecr_credentials" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials"
-
-  repo_name = "test-repo"
-  team_name = "best-team"
-
-  providers = {
-    aws = aws.london
-  }
-}
-```
-
-Note: From version 3.0 of this module, The AWS region  will default to eu-west-2 (London). If you want to deploy to eu-west-1(Ireland), edit the above accordingly.
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 This terraform module will create an ECR repository and IAM credentials to access it.
 
+If `github_repositories` is a non-empty list of strings, [github actions
+secrets] will be created in those repositories, containing the ECR name, AWS
+access key, and AWS secret key.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -14,7 +18,10 @@ This terraform module will create an ECR repository and IAM credentials to acces
 | team_name | name of the team creating the credentials | string | - | yes |
 | aws_region | region into which the resource will be created | string | eu-west-2 | no |
 | providers | provider creating resources | arrays of string | default provider | no |
-
+| github_repositories | List of repositories in which to create github actions secrets | list of strings | no |
+| github_actions_secret_ecr_name | Name of the github actions secret containing the ECR name | ECR_NAME | no |
+| github_actions_secret_ecr_access_key | Name of the github actions secret containing the ECR AWS access key | ECR_AWS_ACCESS_KEY_ID | no |
+| github_actions_secret_ecr_secret_key | Name of the github actions secret containing the ECR AWS secret key | ECR_AWS_SECRET_ACCESS_KEY | no |
 
 ## Outputs
 
@@ -24,3 +31,5 @@ This terraform module will create an ECR repository and IAM credentials to acces
 | secret_access_key | Secret for the new user |
 | repo_arn | ECR repository ARN |
 | repo_url | ECR repository URL |
+
+[github actions secrets]: https://docs.github.com/en/actions/reference/encrypted-secrets

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Note: From version 3.0 of this module, The AWS region  will default to eu-west-2
 |------|-------------|:----:|:-----:|:-----:|
 | repo_name | name of the repository to be created | string | - | yes |
 | team_name | name of the team creating the credentials | string | - | yes |
-| aws_region | region into which the resource will be created | string | eu-west-2 | no
-| providers | provider creating resources | arrays of string | default provider | no
+| aws_region | region into which the resource will be created | string | eu-west-2 | no |
+| providers | provider creating resources | arrays of string | default provider | no |
 
 
 ## Outputs

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -10,10 +10,10 @@ module "example_team_ecr_credentials" {
   team_name = "example-team"
   /*
     By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security
-    / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see: 
-    https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html 
+    / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see:
+    https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
     To disable 'scan_on_push', set it to false as below:
-  scan_on_push = "false"  
+  scan_on_push = "false"
   */
 
   providers = {
@@ -39,7 +39,7 @@ resource "kubernetes_secret" "example_team_ecr_credentials" {
 /*
 #############################################SLACK NOTIFIATIONS OF ECR SCAN RESULTS########################
 
-To send notifications to slack of the ECR image scan results, you may insert the following lambda module that creates the slack lambda function and the event bridge. 
+To send notifications to slack of the ECR image scan results, you may insert the following lambda module that creates the slack lambda function and the event bridge.
 
 The event bridge will be triggered every time there is a scan completed for your ECR repo. The event bridge executes the lambda function which then interacts with slack. A notification containing the scan result will then be sent to your slack channel as per the slack token you specify.
 
@@ -50,7 +50,7 @@ This secret needs to have the following two keys:
 Key 1: repo (without the prefix e.g if the url is 754256621582.dkr.ecr.eu-west-2.amazonaws.com/webops/webops-ecr1:rails, then in this case you need to supply 'webops/webops-ecr1')
 Key 2: token
 
-Below is a sample kubernetes secret yaml you can use to create the secret containing the slack token and ECR repo: 
+Below is a sample kubernetes secret yaml you can use to create the secret containing the slack token and ECR repo:
 
 apiVersion: v1
 kind: Secret
@@ -66,11 +66,11 @@ e.g 'echo -n <SLACK_TOKEN> | base64'
 
 As this file will contain the slack token it is important that it is encyrpted within the repo that has git-encrypt. Also the file must reside within your own team's repo and not a repo that is shared between teams such as the 'cloud-platform-environments'.
 
-Save the above secret yaml with the desired name and create the secret as follows: 
+Save the above secret yaml with the desired name and create the secret as follows:
 
 kubectl create -f <SLACK_SECRET_FILE_NAME>
 
-Lastly, after you have created your kubernetes slack secret as above, move the following lambda module outside the comments section so that it is created alongside your ECR resource. 
+Lastly, after you have created your kubernetes slack secret as above, move the following lambda module outside the comments section so that it is created alongside your ECR resource.
 
 module "ecr_scan_lambda" {
 

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -15,6 +15,11 @@ module "example_team_ecr_credentials" {
     To disable 'scan_on_push', set it to false as below:
   scan_on_push = "false"
   */
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
 }
 
 resource "kubernetes_secret" "example_team_ecr_credentials" {

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -15,10 +15,6 @@ module "example_team_ecr_credentials" {
     To disable 'scan_on_push', set it to false as below:
   scan_on_push = "false"
   */
-
-  providers = {
-    aws = aws.london
-  }
 }
 
 resource "kubernetes_secret" "example_team_ecr_credentials" {

--- a/main.tf
+++ b/main.tf
@@ -59,3 +59,23 @@ resource "aws_iam_user_policy" "policy" {
   user   = aws_iam_user.user.name
 }
 
+resource "github_actions_secret" "ecr_name" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
+  secret_name     = var.github_actions_secret_ecr_name
+  plaintext_value = trimspace(aws_ecr_repository.repo.name)
+}
+
+resource "github_actions_secret" "ecr_access_key" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
+  secret_name     = var.github_actions_secret_ecr_access_key
+  plaintext_value = aws_iam_access_key.key.id
+}
+
+resource "github_actions_secret" "ecr_secret_key" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
+  secret_name     = var.github_actions_secret_ecr_secret_key
+  plaintext_value = aws_iam_access_key.key.secret
+}

--- a/template/ecr.tmpl
+++ b/template/ecr.tmpl
@@ -3,6 +3,11 @@ module "ecr-repo" {
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
+
+  # Uncomment and provide repository names to create github actions secrets
+  # containing the ECR name, AWS access key, and AWS secret key, for use in
+  # github actions CI/CD pipelines
+  # github_repositories = ["my-repo"]
 }
 
 resource "kubernetes_secret" "ecr-repo" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,23 @@ variable "aws_region" {
 variable "scan_on_push" {
   default = true
 }
+
+variable "github_repositories" {
+  description = "GitHub repositories in which to create github actions secrets"
+  default     = []
+}
+
+variable "github_actions_secret_ecr_name" {
+  description = "The name of the github actions secret containing the ECR name"
+  default     = "ECR_NAME"
+}
+
+variable "github_actions_secret_ecr_access_key" {
+  description = "The name of the github actions secret containing the ECR AWS access key"
+  default     = "ECR_AWS_ACCESS_KEY_ID"
+}
+
+variable "github_actions_secret_ecr_secret_key" {
+  description = "The name of the github actions secret containing the ECR AWS secret key"
+  default     = "ECR_AWS_SECRET_ACCESS_KEY"
+}


### PR DESCRIPTION
This change will create github actions secrets in all repositories specified in
the `github_repositories` variable.

The secrets contain the name, AWS access key and AWS secret key for the ECR.

This depends on the concourse pipeline providing `TF_VAR_github_token` and
`TF_VAR_github_owner` environment variables for the github terraform provider.
