### PR TITLE
Create ECR_URL GitHub Actions Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ access key, and AWS secret key.
 | aws_region | region into which the resource will be created | string | eu-west-2 | no |
 | providers | provider creating resources | arrays of string | default provider | no |
 | github_repositories | List of repositories in which to create github actions secrets | list of strings | no |
+| github_actions_secret_ecr_url | Name of the github actions secret containing the ECR URL | ECR_URL | no |
 | github_actions_secret_ecr_name | Name of the github actions secret containing the ECR name | ECR_NAME | no |
 | github_actions_secret_ecr_access_key | Name of the github actions secret containing the ECR AWS access key | ECR_AWS_ACCESS_KEY_ID | no |
 | github_actions_secret_ecr_secret_key | Name of the github actions secret containing the ECR AWS secret key | ECR_AWS_SECRET_ACCESS_KEY | no |

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
   repo_name = "example-module"
   team_name = "example-team"
   /*

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,13 @@ resource "aws_iam_user_policy" "policy" {
   user   = aws_iam_user.user.name
 }
 
+resource "github_actions_secret" "ecr_url" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
+  secret_name     = var.github_actions_secret_ecr_url
+  plaintext_value = trimspace(aws_ecr_repository.repo.repository_url)
+}
+
 resource "github_actions_secret" "ecr_name" {
   for_each        = toset(var.github_repositories)
   repository      = each.key

--- a/template/ecr.tmpl
+++ b/template/ecr.tmpl
@@ -1,5 +1,5 @@
 module "ecr-repo" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.3"
 
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "github_actions_secret_ecr_name" {
   default     = "ECR_NAME"
 }
 
+variable "github_actions_secret_ecr_url" {
+  description = "The name of the github actions secret containing the ECR URL"
+  default     = "ECR_URL"
+}
+
 variable "github_actions_secret_ecr_access_key" {
   description = "The name of the github actions secret containing the ECR AWS access key"
   default     = "ECR_AWS_ACCESS_KEY_ID"


### PR DESCRIPTION
This is easier to use in GitHub Actions workflows.

- Create ECR_URL GitHub Actions Secret in repos.
- ECR module version to 4.3 in example & template

> Please create release 4.3 of the ECR module, after merging this PR