### PR TITLE
Add inspector2 permissions to scan

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,9 @@ data "aws_iam_policy_document" "policy" {
       "ecr:DescribeImages",
       "ecr:BatchGetImage",
       "ecr:ListTagsForResource",
-      "ecr:DescribeImageScanFindings"
+      "ecr:DescribeImageScanFindings",
+      "inspector2:List*",
+      "inspector2:Get*"
     ]
 
     resources = [


### PR DESCRIPTION
This is to fix:
User: arn:aws:iam::754256621582:user/system/*** is not authorized to perform: inspector2:ListFindings on resource:
arn:aws:inspector2:*********:754256621582:/findings/list