### PR TITLE
Add missing variable types and descriptions; give providers minimum versions

### DIFF
--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,9 +1,5 @@
-terraform {
-  required_version = ">= 0.14"
-}
-
 provider "aws" {
-  region                      = "eu-west-2"
+  region = "eu-west-2"
 }
 
 module "ecr" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,39 +1,45 @@
 variable "repo_name" {
+  description = "Name of the repository to be created"
+  type        = string
 }
 
 variable "team_name" {
-}
-
-variable "aws_region" {
-  description = "Region into which the resource will be created."
-  default     = "eu-west-2"
+  description = "Name of the team creating the credentials"
+  type        = string
 }
 
 variable "scan_on_push" {
-  default = true
+  default     = true
+  description = "Whether images are scanned after being pushed to the repository (true) or not (false)"
+  type        = bool
 }
 
 variable "github_repositories" {
   description = "GitHub repositories in which to create github actions secrets"
   default     = []
+  type        = list(string)
 }
 
 variable "github_actions_secret_ecr_name" {
   description = "The name of the github actions secret containing the ECR name"
   default     = "ECR_NAME"
+  type        = string
 }
 
 variable "github_actions_secret_ecr_url" {
   description = "The name of the github actions secret containing the ECR URL"
   default     = "ECR_URL"
+  type        = string
 }
 
 variable "github_actions_secret_ecr_access_key" {
   description = "The name of the github actions secret containing the ECR AWS access key"
   default     = "ECR_AWS_ACCESS_KEY_ID"
+  type        = string
 }
 
 variable "github_actions_secret_ecr_secret_key" {
   description = "The name of the github actions secret containing the ECR AWS secret key"
   default     = "ECR_AWS_SECRET_ACCESS_KEY"
+  type        = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,15 +1,17 @@
 terraform {
+  required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.0.0"
     }
     github = {
-      source = "integrations/github"
-      version = "~> 4.14.0"
+      source  = "integrations/github"
+      version = ">= 4.14.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
     }
   }
-  required_version = ">= 0.14"
 }


### PR DESCRIPTION
This PR does the following:

- removes a duplicated minimum Terraform version from `test/unit-test` (see [here](https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/blob/main/test/unit-test/versions.tf#L7) for where it's already defined)
- runs terraform fmt
- adds missing variable descriptions and types
- gives defined providers a minimum version