### PR TITLE
Update example to 4.7

### DIFF
--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -5,7 +5,7 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.6"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.7"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
 


### PR DESCRIPTION
`cloud-platform-cli` [uses this file as a template](https://github.com/ministryofjustice/cloud-platform-cli/blob/main/pkg/environment/templatesEcr.go#L11) to generate `ecr.tf` files via the CLI, so this PR updates the example version to 4.7