### PR TITLE
Bring .github/ directory up to parity with cloud-platform-terraform-template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,15 +6,14 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@v0.11.0
+      uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
         output-file: README.md
         output-method: inject
         git-push: "true"
-

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,20 +4,20 @@ on:
 
 jobs:
   go-tests:
-    name: Run Terratest Unit Tests
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.x
           terraform_wrapper: false
 
-      - name: Run tf Tests
-        working-directory: test/unit-test
+      - name: Run terraform Tests
+        working-directory: examples/
         run: |
           terraform init
           terraform validate

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If `github_repositories` is a non-empty list of strings, [github actions
 secrets] will be created in those repositories, containing the ECR name, AWS
 access key, and AWS secret key.
 
-<!--- BEGIN_TF_DOCS --->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -78,4 +78,4 @@ No modules.
 | <a name="output_repo_url"></a> [repo\_url](#output\_repo\_url) | ECR repository URL |
 | <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | Secret for the new credentials |
 
-<!--- END_TF_DOCS --->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
This PR brings the `.github` directory up to date with [cloud-platform-terraform-template](https://github.com/ministryofjustice/cloud-platform-terraform-template), including adding Dependabot and workflows for unit tests and documentation.