### PR TITLE
Bump example version

### DIFF
--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -5,17 +5,9 @@
  *
  */
 module "ecr_credentials" {
-  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.0"
+  source    = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=5.1.4"
   team_name = var.team_name
   repo_name = "${var.namespace}-ecr"
-
-  /*
-    By default scan_on_push is set to true. When this is enabled then all images pushed to the repo are scanned for any security
-    / software vulnerabilities in your image and the results can be viewed in the console. For further details, please see:
-    https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html
-    To disable 'scan_on_push', set it to false as below:
-  scan_on_push = "false"
-  */
 
   # Uncomment and provide repository names to create github actions secrets
   # containing the ECR name, AWS access key, and AWS secret key, for use in
@@ -25,6 +17,9 @@ module "ecr_credentials" {
   # list of github environments, to create the ECR secrets as environment secrets
   # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets
   # github_environments = ["my-environment"]
+
+  # Uncomment to configure OIDC for GitHub Actions rather than using access keys
+  # oidc_providers = ["github"]
 
   /*
   # Lifecycle_policy provides a way to automate the cleaning up of your container images by expiring images based on age or count.


### PR DESCRIPTION
This PR bumps the example version to the latest release (`5.1.4`), removes `scan_on_push` from the example as its deprecated, and adds a line about `oidc_providers`.