### PR TITLE
Fix incorrect link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,6 @@ This example is designed to be used in the [cloud-platform-environments](https:/
 
 ## Usage
 
-In your namespace's `resources/` directory in the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/) repository, create a file called `ecr.tf`, and copy the contents of [main.tf](main.tf) into it.
+In your namespace's `resources/` directory in the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/) repository, create a file called `ecr.tf`, and copy the contents of [ecr.tf](ecr.tf) into it.
 
 Change the placeholder values to what is appropriate based on the inline comments, and refer to the top-level [README](../README.md) in this repository for other variables that you can use to customise your resource.


### PR DESCRIPTION
This should state and point to the example ecr file not main.tf.