### PR TITLE
Ready for deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether the ECR should have deletion protection enabled for non-empty registry. Set this to false if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR. | `bool` | `true` | no |
 | <a name="input_github_actions_prefix"></a> [github\_actions\_prefix](#input\_github\_actions\_prefix) | String prefix for GitHub Actions variable and secrets key | `string` | `""` | no |
 | <a name="input_github_actions_secret_ecr_access_key"></a> [github\_actions\_secret\_ecr\_access\_key](#input\_github\_actions\_secret\_ecr\_access\_key) | The name of the github actions secret containing the ECR AWS access key | `string` | `"ECR_AWS_ACCESS_KEY_ID"` | no |
 | <a name="input_github_actions_secret_ecr_name"></a> [github\_actions\_secret\_ecr\_name](#input\_github\_actions\_secret\_ecr\_name) | The name of the github actions secret containing the ECR name | `string` | `"ECR_NAME"` | no |
@@ -92,7 +93,6 @@ No modules.
 | <a name="input_lifecycle_policy"></a> [lifecycle\_policy](#input\_lifecycle\_policy) | A lifecycle policy consists of one or more rules that determine which images in a repository should be expired. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name | `string` | `null` | no |
 | <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | OIDC providers for this ECR repository, valid values are "github" or "circleci" | `list(string)` | `[]` | no |
-| <a name="input_ready_for_deletion"></a> [ready\_for\_deletion](#input\_ready\_for\_deletion) | Set this to true if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR. | `bool` | `false` | no |
 | <a name="input_repo_name"></a> [repo\_name](#input\_repo\_name) | Name of the repository to be created | `string` | n/a | yes |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Whether images are scanned after being pushed to the repository (true) or not (false) | `bool` | `true` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Name of the team creating the credentials | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ No modules.
 | <a name="input_lifecycle_policy"></a> [lifecycle\_policy](#input\_lifecycle\_policy) | A lifecycle policy consists of one or more rules that determine which images in a repository should be expired. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name | `string` | `null` | no |
 | <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | OIDC providers for this ECR repository, valid values are "github" or "circleci" | `list(string)` | `[]` | no |
+| <a name="input_ready_for_deletion"></a> [ready\_for\_deletion](#input\_ready\_for\_deletion) | Set this to true if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR. | `bool` | `false` | no |
 | <a name="input_repo_name"></a> [repo\_name](#input\_repo\_name) | Name of the repository to be created | `string` | n/a | yes |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Whether images are scanned after being pushed to the repository (true) or not (false) | `bool` | `true` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Name of the team creating the credentials | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether the ECR should have deletion protection enabled for non-empty registry. Set this to false if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR. | `bool` | `true` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | (Optional) Whether the ECR should have deletion protection enabled for non-empty registry. Set this to false if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR. Defaults to true. | `bool` | `true` | no |
 | <a name="input_github_actions_prefix"></a> [github\_actions\_prefix](#input\_github\_actions\_prefix) | String prefix for GitHub Actions variable and secrets key | `string` | `""` | no |
 | <a name="input_github_actions_secret_ecr_access_key"></a> [github\_actions\_secret\_ecr\_access\_key](#input\_github\_actions\_secret\_ecr\_access\_key) | The name of the github actions secret containing the ECR AWS access key | `string` | `"ECR_AWS_ACCESS_KEY_ID"` | no |
 | <a name="input_github_actions_secret_ecr_name"></a> [github\_actions\_secret\_ecr\_name](#input\_github\_actions\_secret\_ecr\_name) | The name of the github actions secret containing the ECR name | `string` | `"ECR_NAME"` | no |

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -70,10 +70,10 @@ module "ecr" {
     EOF
   */
 
-  # OPTIONAL: Add this parameter when you are planning on either deleting your environment namespace or ECR resource.
+  # OPTIONAL: Add deletion_protection = false parameter if you are planning on either deleting your environment namespace or ECR resource.
   # IMPORTANT: It is the PR owners responsibility to ensure that no other environments are sharing this ECR registry.
   # This flag will allow a non-empty ECR to be deleted.
-  # Defaults to false
+  # Defaults to true
   
-  # ready_for_deletion = true
+  # deletion_protection = false
 }

--- a/examples/ecr.tf
+++ b/examples/ecr.tf
@@ -69,4 +69,11 @@ module "ecr" {
     }
     EOF
   */
+
+  # OPTIONAL: Add this parameter when you are planning on either deleting your environment namespace or ECR resource.
+  # IMPORTANT: It is the PR owners responsibility to ensure that no other environments are sharing this ECR registry.
+  # This flag will allow a non-empty ECR to be deleted.
+  # Defaults to false
+  
+  # ready_for_deletion = true
 }

--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,8 @@ resource "aws_ecr_repository" "repo" {
   name = "${var.team_name}/${var.repo_name}"
   image_scanning_configuration {
     scan_on_push = var.scan_on_push
-    force_delete = var.ready_for_deletion
   }
+  force_delete = var.ready_for_deletion
 }
 
 # ECR lifecycle policy

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_ecr_repository" "repo" {
   image_scanning_configuration {
     scan_on_push = var.scan_on_push
   }
-  force_delete = var.ready_for_deletion
+  force_delete = var.deletion_protection ? false : true
 }
 
 # ECR lifecycle policy

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ resource "aws_ecr_repository" "repo" {
   name = "${var.team_name}/${var.repo_name}"
   image_scanning_configuration {
     scan_on_push = var.scan_on_push
+    force_delete = var.ready_for_deletion
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -78,8 +78,8 @@ variable "github_actions_prefix" {
   default     = ""
 }
 
-variable "ready_for_deletion" {
-  description = "Set this to true if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR."
+variable "deletion_protection" {
+  description = "Whether the ECR should have deletion protection enabled for non-empty registry. Set this to false if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,3 +77,9 @@ variable "github_actions_prefix" {
   type        = string
   default     = ""
 }
+
+variable "ready_for_deletion" {
+  description = "Set this to true if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "github_actions_prefix" {
 }
 
 variable "deletion_protection" {
-  description = "Whether the ECR should have deletion protection enabled for non-empty registry. Set this to false if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR."
+  description = "(Optional) Whether the ECR should have deletion protection enabled for non-empty registry. Set this to false if you intend to delete your ECR resource or namespace. NOTE: PR owner has responsibility to ensure that no other environments are sharing this ECR. Defaults to true."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
This PR adds optional variable `deletion_protection` , which when set to `false`, will switch the `force_delete` argument to true as a preparatory step for deleting a namespace/ECR resource to avoid terraform failure on non-empty ECRs.