### PR TITLE
Remove ability to turn off scan_on_push

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ No modules.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name | `string` | `null` | no |
 | <a name="input_oidc_providers"></a> [oidc\_providers](#input\_oidc\_providers) | OIDC providers for this ECR repository, valid values are "github" or "circleci" | `list(string)` | `[]` | no |
 | <a name="input_repo_name"></a> [repo\_name](#input\_repo\_name) | Name of the repository to be created | `string` | n/a | yes |
-| <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Whether images are scanned after being pushed to the repository (true) or not (false) | `bool` | `true` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Name of the team creating the credentials | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ data "aws_region" "current" {}
 resource "aws_ecr_repository" "repo" {
   name = "${var.team_name}/${var.repo_name}"
   image_scanning_configuration {
-    scan_on_push = var.scan_on_push
+    scan_on_push = true
   }
   force_delete = var.deletion_protection ? false : true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,12 +14,6 @@ variable "namespace" {
   default     = null
 }
 
-variable "scan_on_push" {
-  default     = true
-  description = "Whether images are scanned after being pushed to the repository (true) or not (false)"
-  type        = bool
-}
-
 variable "github_repositories" {
   description = "GitHub repositories in which to create github actions secrets"
   default     = []


### PR DESCRIPTION
This has been deprecated in favour of an account-wide setting (which is set to `true`), so we'll just always keep this enabled.

See the [blog post](https://aws.amazon.com/blogs/containers/container-scanning-updates-in-amazon-ecr-private-registries-using-amazon-inspector/).