### PR TITLE
♻️ Refactor GitHub Actions to Store ECR Registry URL as a Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ No modules.
 | [github_actions_environment_secret.ecr_role_to_assume](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
 | [github_actions_environment_variable.ecr_region](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_variable) | resource |
 | [github_actions_environment_variable.ecr_repository](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_variable) | resource |
+| [github_actions_secret.ecr_registry_url](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.ecr_role_to_assume](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_variable.ecr_region](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_variable) | resource |
 | [github_actions_variable.ecr_repository](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_variable) | resource |


### PR DESCRIPTION
## 👀 Purpose

- This PR refactors the main.tf file in this repository by moving the dynamically gathered ECR registry URL into a GitHub secret. The primary goal is to enhance security, improve workflow maintainability, and follow best practices for managing sensitive information in CI/CD pipelines.
- There are many articles and examples on why we shouldn't expose the AWS account data. Here are a few:
   1. https://www.plerion.com/blog/the-final-answer-aws-account-ids-are-secrets
   2. https://www.lastweekinaws.com/blog/are-aws-account-ids-sensitive-information/

## ♻️ What's changed

- The ECR registry URL is now stored as a GitHub secret (ECR_REGISTRY_URL) instead of being [dynamically retrieved](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/create.html#github-actions-example-workflow) and exposed in workflow logs. This change ensures that sensitive AWS account information, including the registry URL, is not visible in plaintext during workflow execution.

- GitHub automatically masks secrets in logs, mitigating the risk of inadvertently exposing sensitive information.

## 📝 Notes

- The workflow configuration is now cleaner and easier to maintain, as sensitive information is handled through GitHub's secret management.

- Developers no longer need to retrieve the registry dynamically within each step. The secret is pre-defined and can be referenced easily, leading to more concise and readable workflows.

Rationale:

- By moving the ECR registry URL to a secret, we follow the principle of least privilege and limit the exposure of sensitive information.

- It simplifies onboarding for new projects or teams, as the registry information is centrally managed and can be easily updated without modifying the workflow logic itself.

- This change enhances the overall security posture of our CI/CD workflows and aligns with industry best practices.