### PR TITLE
fix: support GitHub OIDC immutable subject claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ module "ecr" {
 
 This change has been introduced to support Cloud Platform's effort in reducing the count of unused IAM policies 
 
+## GitHub OIDC subject claims
+
+GitHub changed the format of the OIDC token subject (`sub`) claim. Repositories created after 15 July 2026, along with repositories renamed or transferred after that date, now use an immutable subject that includes the numeric owner ID and repository ID. The subject changes from `repo:ministryofjustice/<repo>:...` to `repo:ministryofjustice@<owner_id>/<repo>@<repo_id>:...`.
+
+The IAM role trust policy created by this module matches both formats, so GitHub Actions authentication keeps working whether your repository uses the older name-based subject or the newer immutable one. You do not need to change anything in your module call.
+
+For background, see [GitHub's OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc).
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ GitHub changed the format of the OIDC token subject (`sub`) claim. Repositories 
 
 The IAM role trust policy created by this module matches both formats, so GitHub Actions authentication keeps working whether your repository uses the older name-based subject or the newer immutable one. You do not need to change anything in your module call.
 
-For background, see [GitHub's OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc).
+For background, see [GitHub's OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims).
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/main.tf
+++ b/main.tf
@@ -282,9 +282,12 @@ data "aws_iam_policy_document" "github" {
     }
 
     condition {
-      test     = (length(local.github_repos) == 1) ? "StringLike" : "ForAnyValue:StringLike"
+      test     = "ForAnyValue:StringLike"
       variable = "${local.oidc_providers.github}:sub"
-      values   = formatlist("repo:ministryofjustice/%s:*", local.github_repos)
+      values = concat(
+        formatlist("repo:ministryofjustice/%s:*", local.github_repos),
+        formatlist("repo:ministryofjustice@*/%s@*:*", local.github_repos),
+      )
     }
 
     condition {


### PR DESCRIPTION
GitHub moved to an immutable OIDC subject format for repositories created, renamed, or transferred after 15 July 2026. The subject now includes the numeric owner ID and repository ID, e.g.
repo:ministryofjustice@<owner_id>/<repo>@<repo_id>:...

The GitHub IAM role trust policy previously matched only the legacy name-based subject (repo:ministryofjustice/<repo>:*), so affected repos failed with 'Not authorized to perform sts:AssumeRoleWithWebIdentity'.

Match both the legacy and immutable subject formats so authentication works regardless of which format GitHub issues.